### PR TITLE
Add FireForgetPublisher.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: go
 
 go:
-  - 1.9.x
+  - "1.10.x"
+  - "1.11.x"
   - tip
 
 services:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.4.0
+- [LightningPool](https://godoc.org/github.com/furdarius/rabbitroutine#LightningPool) added.
+- [FireForgetPublisher](https://godoc.org/github.com/furdarius/rabbitroutine#FireForgetPublisher) added.
+- Possible deadlock on channel receiving from Dialed event listener fixed.
+- [RetryPublisher](https://godoc.org/github.com/furdarius/rabbitroutine#RetryPublisher) accepts [Publisher](https://godoc.org/github.com/furdarius/rabbitroutine#Publisher) interface now.
+
 # 0.3.1
 - On error wait for c.cfg.Wait time before consumer restart.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.4.0
+# 0.4.0 | [Pull request](https://github.com/furdarius/rabbitroutine/pull/3)
 - [LightningPool](https://godoc.org/github.com/furdarius/rabbitroutine#LightningPool) added.
 - [FireForgetPublisher](https://godoc.org/github.com/furdarius/rabbitroutine#FireForgetPublisher) added.
 - Possible deadlock on channel receiving from Dialed event listener fixed.

--- a/connector.go
+++ b/connector.go
@@ -305,8 +305,6 @@ func (c *Connector) DialConfig(ctx context.Context, url string, config amqp.Conf
 			return errors.WithMessage(err, "failed to dial")
 		}
 
-		c.emitDialed(Dialed{})
-
 		// In the case of connection problems,
 		// we will get an error from closeCh
 		closeCh := c.conn.NotifyClose(make(chan *amqp.Error, 1))
@@ -314,6 +312,8 @@ func (c *Connector) DialConfig(ctx context.Context, url string, config amqp.Conf
 		broadcastCtx, cancel := context.WithCancel(ctx)
 		go c.connBroadcast(broadcastCtx)
 
+		c.emitDialed(Dialed{})
+		
 		select {
 		case <-ctx.Done():
 			cancel()

--- a/pool.go
+++ b/pool.go
@@ -95,7 +95,7 @@ func (p *Pool) new(ctx context.Context) (ChannelKeeper, error) {
 
 	err = ch.Confirm(false)
 	if err != nil {
-		_ = ch.Close()
+		_ = ch.Close() //nolint: gosec
 
 		return keep, errors.Wrap(err, "failed to setup confirm mode for channel")
 	}

--- a/pool_test.go
+++ b/pool_test.go
@@ -55,3 +55,44 @@ func TestPoolAcquiringFromNonEmpty(t *testing.T) {
 	assert.NotNil(t, k.errorCh)
 	assert.NotNil(t, k.confirmCh)
 }
+
+func TestLightningPoolChannelRespectContext(t *testing.T) {
+	defer time.AfterFunc(1*time.Second, func() { panic("LightningPool.Channel don't respect context") }).Stop()
+
+	conn := NewConnector(Config{})
+	pool := NewLightningPool(conn)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := pool.Channel(ctx)
+	assert.Error(t, err)
+	assert.Equal(t, errors.Cause(err), ctx.Err())
+}
+
+func TestLightningPoolEmptyOnStart(t *testing.T) {
+	conn := NewConnector(Config{})
+	pool := NewLightningPool(conn)
+
+	assert.Empty(t, pool.set)
+}
+
+func TestLightningPoolReleaseSuccess(t *testing.T) {
+	conn := NewConnector(Config{})
+	pool := NewLightningPool(conn)
+
+	pool.Release(&amqp.Channel{})
+	assert.Len(t, pool.set, 1)
+}
+
+func TestLightningPoolAcquiringFromNonEmpty(t *testing.T) {
+	conn := NewConnector(Config{})
+	pool := NewLightningPool(conn)
+
+	pool.Release(&amqp.Channel{})
+	assert.Len(t, pool.set, 1)
+
+	_, err := pool.Channel(context.Background())
+	assert.NoError(t, err)
+	assert.Empty(t, pool.set)
+}

--- a/publisher.go
+++ b/publisher.go
@@ -40,7 +40,7 @@ func (p *EnsurePublisher) Publish(ctx context.Context, exchange, key string, msg
 
 	err = ch.Publish(exchange, key, false, false, msg)
 	if err != nil {
-		_ = k.Close()
+		_ = k.Close() //nolint: gosec
 
 		return errors.Wrap(err, "failed to publish message")
 	}
@@ -48,11 +48,11 @@ func (p *EnsurePublisher) Publish(ctx context.Context, exchange, key string, msg
 	select {
 	case <-ctx.Done():
 		// Do not return to pool, because old confirmation will be waited.
-		_ = k.Close()
+		_ = k.Close() //nolint: gosec
 
 		return ctx.Err()
 	case amqpErr := <-k.Error():
-		_ = k.Close()
+		_ = k.Close() //nolint: gosec
 
 		return errors.Wrap(amqpErr, "failed to deliver a message")
 	case <-k.Confirm():
@@ -83,7 +83,7 @@ func (p *FireForgetPublisher) Publish(ctx context.Context, exchange, key string,
 
 	err = ch.Publish(exchange, key, false, false, msg)
 	if err != nil {
-		_ = ch.Close()
+		_ = ch.Close() //nolint: gosec
 
 		return errors.Wrap(err, "failed to publish message")
 	}

--- a/publisher_example_test.go
+++ b/publisher_example_test.go
@@ -10,8 +10,46 @@ import (
 	"github.com/streadway/amqp"
 )
 
-// This example demonstrates publishing messages in RabbitMQ exchange.
-func ExamplePublisher() {
+// This example demonstrates publishing messages in RabbitMQ exchange using FireForgetPublisher.
+func ExampleFireForgetPublisher() {
+	ctx := context.Background()
+
+	url := "amqp://guest:guest@127.0.0.1:5672/"
+
+	conn := rabbitroutine.NewConnector(rabbitroutine.Config{
+		// Max reconnect attempts
+		ReconnectAttempts: 20000,
+		// How long wait between reconnect
+		Wait: 2 * time.Second,
+	})
+
+	pool := rabbitroutine.NewLightningPool(conn)
+	pub := rabbitroutine.NewFireForgetPublisher(pool)
+
+	go func() {
+		err := conn.Dial(ctx, url)
+		if err != nil {
+			log.Println("failed to establish RabbitMQ connection:", err)
+		}
+	}()
+
+	for i := 0; i < 5000; i++ {
+		timeoutCtx, cancel := context.WithTimeout(ctx, 100*time.Millisecond)
+
+		err := pub.Publish(timeoutCtx, "myexch", "myqueue", amqp.Publishing{
+			Body: []byte(fmt.Sprintf("message %d", i)),
+		})
+		if err != nil {
+			log.Println("failed to publish:", err)
+		}
+
+		cancel()
+	}
+}
+
+// This example demonstrates publishing messages in RabbitMQ exchange delivery guarantees by EnsurePublisher
+// and publishing retries by RetryPublisher.
+func ExampleEnsurePublisher() {
 	ctx := context.Background()
 
 	url := "amqp://guest:guest@127.0.0.1:5672/"


### PR DESCRIPTION
- [LightningPool](https://godoc.org/github.com/furdarius/rabbitroutine#LightningPool) added.
- [FireForgetPublisher](https://godoc.org/github.com/furdarius/rabbitroutine#FireForgetPublisher) added.
- Possible deadlock on channel receiving from Dialed event listener fixed.
- [RetryPublisher](https://godoc.org/github.com/furdarius/rabbitroutine#RetryPublisher) accepts [Publisher](https://godoc.org/github.com/furdarius/rabbitroutine#Publisher) interface now.