### PR TITLE
EnsurePublisher handles no-route error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.5.0 | [Pull request](https://github.com/furdarius/rabbitroutine/pull/9)
+- [EnsurePublisher.Publish](https://godoc.org/github.com/furdarius/rabbitroutine#EnsurePublisher.Publish) returns [ErrNotFound](https://godoc.org/github.com/furdarius/rabbitroutine#ErrNotFound) if RabbitMQ entity (e.g. exchange) doesn't exist.
+- [EnsurePublisher.Publish](https://godoc.org/github.com/furdarius/rabbitroutine#EnsurePublisher.Publish) returns [ErrNoRoute](https://godoc.org/github.com/furdarius/rabbitroutine#ErrNoRoute) if message cannot be delivered to any queue.
+- Functional options for configuring RetryPublisher added.
+- NewRetryPublisherWithDelay deleted.
+
 # 0.4.2 | [Pull request](https://github.com/furdarius/rabbitroutine/pull/8)
 - Fix compile error on Windows `GOOS=windows GOARCH=386 go build` ([issue](https://github.com/furdarius/rabbitroutine/issues/7))
 

--- a/README.md
+++ b/README.md
@@ -97,7 +97,11 @@ conn := rabbitroutine.NewConnector(rabbitroutine.Config{
 
 pool := rabbitroutine.NewPool(conn)
 ensurePub := rabbitroutine.NewEnsurePublisher(pool)
-pub := rabbitroutine.NewRetryPublisher(ensurePub)
+pub := rabbitroutine.NewRetryPublisher(
+    ensurePub,
+    rabbitroutine.PublishMaxAttemptsSetup(16),
+    rabbitroutine.PublishDelaySetup(rabbitroutine.LinearDelay(10*time.Millisecond)),
+)
 
 go conn.Dial(ctx, url)
 
@@ -120,7 +124,7 @@ To run the integration tests, make sure you have RabbitMQ running on any host,
 export the environment variable `AMQP_URL=amqp://host/` and run `go test -tags
 integration`. As example:
 ```
-AMQP_URL=amqp://guest:guest@127.0.0.1:5672/ go test -v -race -cpu=1,2 -tags integration -timeout 2s
+AMQP_URL=amqp://guest:guest@127.0.0.1:5672/ go test -v -race -cpu=1,2 -tags integration -timeout 5s
 ```
 
 Use `gometalinter` to check code with linters:

--- a/README.md
+++ b/README.md
@@ -12,10 +12,10 @@ The library is designed to save the developer from the headache when working wit
 **rabbitroutine** solves your RabbitMQ reconnection problems:
 * Handles connection errors and channels errors separately.
 * Takes into account the need to [re-declare](https://godoc.org/github.com/furdarius/rabbitroutine#Consumer) entities in RabbitMQ after reconnection.
-* Allow you to log [errors](https://godoc.org/github.com/furdarius/rabbitroutine#Connector.AddAMQPNotifiedListener) or connection [retry attempts](https://godoc.org/github.com/furdarius/rabbitroutine#Connector.AddRetriedListener).
+* Notifies of [errors](https://godoc.org/github.com/furdarius/rabbitroutine#Connector.AddAMQPNotifiedListener) and connection [retry attempts](https://godoc.org/github.com/furdarius/rabbitroutine#Connector.AddRetriedListener).
 * Supports [FireAndForgetPublisher](https://godoc.org/github.com/furdarius/rabbitroutine#FireForgetPublisher) and [EnsurePublisher](https://godoc.org/github.com/furdarius/rabbitroutine#EnsurePublisher), that can be wrapped with [RetryPublisher](https://godoc.org/github.com/furdarius/rabbitroutine#RetryPublisher).
 * Supports pool of channels used for publishing.
-* Allow you to receive current channels pool size.
+* Provides channels [pool size](https://godoc.org/github.com/furdarius/rabbitroutine#Pool.Size) statistics.
 
 **Stop to do wrappers, do features!**
 

--- a/examples/consume/consumer.go
+++ b/examples/consume/consumer.go
@@ -37,9 +37,7 @@ func (c *Consumer) Declare(ctx context.Context, ch *amqp.Channel) error {
 		false,       // delete when unused
 		false,       // exclusive
 		false,       // no-wait
-		amqp.Table{
-			"x-max-length": int64(40),
-		},
+		nil,
 	)
 	if err != nil {
 		log.Printf("failed to declare queue %v: %v", c.QueueName, err)

--- a/examples/consume/main.go
+++ b/examples/consume/main.go
@@ -42,7 +42,7 @@ func main() {
 	})
 
 	consumer := &Consumer{
-		ExchangeName: "myexch",
+		ExchangeName: "myexchange",
 		QueueName:    "myqueue",
 	}
 

--- a/publisher_test.go
+++ b/publisher_test.go
@@ -75,7 +75,91 @@ func TestRetryPublisherDelaySetup(t *testing.T) {
 	pool := NewPool(conn)
 	ensurePub := NewEnsurePublisher(pool)
 
-	expected := 999 * time.Millisecond
-	pub := NewRetryPublisherWithDelay(ensurePub, expected)
-	assert.Equal(t, expected, pub.delay)
+	expected := 42 * time.Millisecond
+
+	pub := NewRetryPublisher(ensurePub, PublishDelaySetup(ConstDelay(expected)))
+
+	actual := pub.delayFn(1)
+	assert.Equal(t, expected, actual)
+}
+
+func TestRetryPublisherMaxAttemptsSetup(t *testing.T) {
+	conn := NewConnector(Config{})
+	pool := NewPool(conn)
+	ensurePub := NewEnsurePublisher(pool)
+
+	expected := uint(42)
+
+	pub := NewRetryPublisher(ensurePub, PublishMaxAttemptsSetup(expected))
+
+	actual := pub.maxAttempts
+	assert.Equal(t, expected, actual)
+}
+
+func TestConstDelay(t *testing.T) {
+	tests := []struct {
+		delayFn  RetryDelayFunc
+		attempt  uint
+		expected time.Duration
+	}{
+		{
+			delayFn:  ConstDelay(10 * time.Millisecond),
+			attempt:  1,
+			expected: 10 * time.Millisecond,
+		},
+		{
+			delayFn:  ConstDelay(10 * time.Millisecond),
+			attempt:  5,
+			expected: 10 * time.Millisecond,
+		},
+		{
+			delayFn:  ConstDelay(120 * time.Millisecond),
+			attempt:  52,
+			expected: 120 * time.Millisecond,
+		},
+		{
+			delayFn:  ConstDelay(time.Second),
+			attempt:  99,
+			expected: time.Second,
+		},
+	}
+
+	for _, test := range tests {
+		actual := test.delayFn(test.attempt)
+		assert.Equal(t, test.expected, actual)
+	}
+}
+
+func TestLinearDelay(t *testing.T) {
+	tests := []struct {
+		delayFn  RetryDelayFunc
+		attempt  uint
+		expected time.Duration
+	}{
+		{
+			delayFn:  LinearDelay(10 * time.Millisecond),
+			attempt:  1,
+			expected: 10 * time.Millisecond,
+		},
+		{
+			delayFn:  LinearDelay(10 * time.Millisecond),
+			attempt:  5,
+			expected: 50 * time.Millisecond,
+		},
+		{
+			delayFn:  LinearDelay(120 * time.Millisecond),
+			attempt:  52,
+			expected: 6240 * time.Millisecond,
+		},
+		{
+			delayFn:  LinearDelay(time.Second),
+			attempt:  99,
+			expected: 99 * time.Second,
+		},
+	}
+
+	for _, test := range tests {
+		actual := test.delayFn(test.attempt)
+		assert.Equal(t, test.expected, actual)
+	}
 }


### PR DESCRIPTION
* [EnsurePublisher](https://godoc.org/github.com/furdarius/rabbitroutine#EnsurePublisher) will publish messages with mandatory flag and return error if no queue is bound that matches the routing key. (https://www.rabbitmq.com/amqp-0-9-1-errata.html#section_17) This will avoid losing messages when the box exists without a queue.
* RetryPublisher creation extended with functional options (e.g. max publishing attempt and flexible delay).