### PR TITLE
Pass RetryPublisher attempt number in ctx

### DIFF
--- a/publisher.go
+++ b/publisher.go
@@ -147,7 +147,7 @@ type RetryPublisher struct {
 	maxAttempts uint
 	// delayFn returns how long to wait before next retry
 	delayFn RetryDelayFunc
-	// retryAttemptContextKey, if non-empty, to add attempt uint value before calling innter publisher
+	// retryAttemptContextKey used to pass retry attempt count to inner publisher via context
 	retryAttemptContextKey string
 }
 

--- a/publisher.go
+++ b/publisher.go
@@ -10,12 +10,20 @@ import (
 	"github.com/streadway/amqp"
 )
 
+type contextKey string
+
+func (c contextKey) String() string {
+	return "rabbitroutine context key " + string(c)
+}
+
 var (
 	// ErrNotFound indicates that RabbitMQ entity doesn't exist.
 	ErrNotFound = errors.New("rabbitmq entity not found")
 	// ErrNoRoute indicates that queue is bound that matches the routing key.
 	// @see: https://www.rabbitmq.com/amqp-0-9-1-errata.html#section_17
 	ErrNoRoute = errors.New("queue not bound")
+	// retryAttemptContextKey is added to the context of RetryPublisher with the retry attempt number value.
+	retryAttemptContextKey = contextKey("retry-attempt")
 )
 
 // Publisher interface provides functionality of publishing to RabbitMQ.
@@ -147,17 +155,14 @@ type RetryPublisher struct {
 	maxAttempts uint
 	// delayFn returns how long to wait before next retry
 	delayFn RetryDelayFunc
-	// retryAttemptContextKey used to pass retry attempt count to inner publisher via context
-	retryAttemptContextKey string
 }
 
 // NewRetryPublisher returns a new instance of RetryPublisherOption.
 func NewRetryPublisher(p Publisher, opts ...RetryPublisherOption) *RetryPublisher {
 	pub := &RetryPublisher{
-		Publisher:              p,
-		maxAttempts:            math.MaxUint32,
-		delayFn:                ConstDelay(10 * time.Millisecond),
-		retryAttemptContextKey: "",
+		Publisher:   p,
+		maxAttempts: math.MaxUint32,
+		delayFn:     ConstDelay(10 * time.Millisecond),
 	}
 
 	for _, option := range opts {
@@ -174,9 +179,7 @@ func (p *RetryPublisher) Publish(ctx context.Context, exchange, key string, msg 
 	var err error
 
 	for attempt := uint(1); attempt <= p.maxAttempts; attempt++ {
-		if p.retryAttemptContextKey != "" {
-			ctx = context.WithValue(ctx, p.retryAttemptContextKey, attempt)
-		}
+		ctx = context.WithValue(ctx, retryAttemptContextKey, attempt)
 		err = p.Publisher.Publish(ctx, exchange, key, msg)
 		if err != nil {
 			select {
@@ -193,6 +196,13 @@ func (p *RetryPublisher) Publish(ctx context.Context, exchange, key string, msg 
 	return err
 }
 
+// RetryAttempt returns the current retry attempt of a message published by RetryPublisher.
+// If the retry attempt key is not set in the context, returns false as second value.
+func RetryAttempt(ctx context.Context) (uint, bool) {
+	retryAttempt, ok := ctx.Value(retryAttemptContextKey).(uint)
+	return retryAttempt, ok
+}
+
 // PublishDelaySetup sets function for publish delay time.Duration receiving.
 func PublishDelaySetup(fn RetryDelayFunc) RetryPublisherOption {
 	return func(pub *RetryPublisher) {
@@ -204,13 +214,6 @@ func PublishDelaySetup(fn RetryDelayFunc) RetryPublisherOption {
 func PublishMaxAttemptsSetup(maxAttempts uint) RetryPublisherOption {
 	return func(pub *RetryPublisher) {
 		pub.maxAttempts = maxAttempts
-	}
-}
-
-// PublishRetryAttemptContextKeySetup sets the key context key used to pass retry attempt uint to the inner publisher.
-func PublishRetryAttemptContextKeySetup(retryAttemptContextKey string) RetryPublisherOption {
-	return func(pub *RetryPublisher) {
-		pub.retryAttemptContextKey = retryAttemptContextKey
 	}
 }
 


### PR DESCRIPTION
hey! we currently have a rabbitroutine setup that is: 

`rabbitroutine.RetryPublisher` -> `TelemetryPublisher` (our own publisher wrapper) -> `rabboutroutine.Ensure/FireForgetPublisher`. we use the `TelemetryPublisher` to capture stats on our rabbitmq publishing and would like to be able to emit the retry attempt number on a given publish attempt as part of that info.

~this PR allows `RetryPublisher` to be configured so that it passes the current retry attempt to the inner publisher as a context key/value pair. if this is something y'all would be interested in, let me know how I can help get this merged!~ updated to follow this library context key pattern: https://medium.com/@matryer/context-keys-in-go-5312346a868d